### PR TITLE
홈베이스 예약 멤버 명단 수정하기

### DIFF
--- a/src/main/java/msg/team1/Hi/domain/home_base/presentation/controller/admin/AdminHomeBaseController.java
+++ b/src/main/java/msg/team1/Hi/domain/home_base/presentation/controller/admin/AdminHomeBaseController.java
@@ -25,7 +25,6 @@ public class AdminHomeBaseController {
     private final GetAllReservationService getAllReservationService;
     private final GetReservationService getReservationService;
     private final UpdateReservationTeamNameService updateReservationTeamNameService;
-    private final UpdateReservationMemberService updateReservationMemberService;
 
     @PostMapping("/reserve")
     public ResponseEntity<Void> reserveHomeBase(@Valid @RequestBody ReserveHomeBaseRequest request) {

--- a/src/main/java/msg/team1/Hi/domain/home_base/presentation/controller/admin/AdminHomeBaseController.java
+++ b/src/main/java/msg/team1/Hi/domain/home_base/presentation/controller/admin/AdminHomeBaseController.java
@@ -2,7 +2,6 @@ package msg.team1.Hi.domain.home_base.presentation.controller.admin;
 
 import lombok.RequiredArgsConstructor;
 import msg.team1.Hi.domain.home_base.presentation.dto.request.ReserveHomeBaseRequest;
-import msg.team1.Hi.domain.home_base.presentation.dto.request.UpdateReservationMemberRequest;
 import msg.team1.Hi.domain.home_base.presentation.dto.response.LookUpReservationDetailResponse;
 import msg.team1.Hi.domain.home_base.presentation.dto.response.LookUpReservationResponse;
 import msg.team1.Hi.domain.home_base.service.ReserveHomeBaseService;
@@ -48,14 +47,8 @@ public class AdminHomeBaseController {
     }
 
     @PatchMapping("/{reservation_id}/name")
-    public ResponseEntity<Void> updateReservationTeamName(@PathVariable("reservation_id") Long reservationId, @RequestParam String teamName){
+    public ResponseEntity<Void> updateReservationTeamName(@PathVariable("reservation_id") Long reservationId, @RequestParam String teamName) {
         updateReservationTeamNameService.execute(reservationId, teamName);
-        return ResponseEntity.noContent().build();
-    }
-
-    @PatchMapping("/{reservation_id}/update-member")
-    public ResponseEntity<Void> updateReservationMembers(@PathVariable("reservation_id") Long reservationId, @RequestBody UpdateReservationMemberRequest request) {
-        updateReservationMemberService.execute(request, reservationId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/msg/team1/Hi/domain/home_base/presentation/controller/admin/AdminHomeBaseController.java
+++ b/src/main/java/msg/team1/Hi/domain/home_base/presentation/controller/admin/AdminHomeBaseController.java
@@ -2,11 +2,13 @@ package msg.team1.Hi.domain.home_base.presentation.controller.admin;
 
 import lombok.RequiredArgsConstructor;
 import msg.team1.Hi.domain.home_base.presentation.dto.request.ReserveHomeBaseRequest;
+import msg.team1.Hi.domain.home_base.presentation.dto.request.UpdateReservationMemberRequest;
 import msg.team1.Hi.domain.home_base.presentation.dto.response.LookUpReservationDetailResponse;
 import msg.team1.Hi.domain.home_base.presentation.dto.response.LookUpReservationResponse;
 import msg.team1.Hi.domain.home_base.service.ReserveHomeBaseService;
 import msg.team1.Hi.domain.reservation.service.GetAllReservationService;
 import msg.team1.Hi.domain.reservation.service.GetReservationService;
+import msg.team1.Hi.domain.reservation.service.UpdateReservationMemberService;
 import msg.team1.Hi.domain.reservation.service.UpdateReservationTeamNameService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +26,7 @@ public class AdminHomeBaseController {
     private final GetAllReservationService getAllReservationService;
     private final GetReservationService getReservationService;
     private final UpdateReservationTeamNameService updateReservationTeamNameService;
+    private final UpdateReservationMemberService updateReservationMemberService;
 
     @PostMapping("/reserve")
     public ResponseEntity<Void> reserveHomeBase(@Valid @RequestBody ReserveHomeBaseRequest request) {
@@ -47,6 +50,12 @@ public class AdminHomeBaseController {
     @PatchMapping("/{reservation_id}/name")
     public ResponseEntity<Void> updateReservationTeamName(@PathVariable("reservation_id") Long reservationId, @RequestParam String teamName){
         updateReservationTeamNameService.execute(reservationId, teamName);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{reservation_id}/update-member")
+    public ResponseEntity<Void> updateReservationMembers(@PathVariable("reservation_id") Long reservationId, @RequestBody UpdateReservationMemberRequest request) {
+        updateReservationMemberService.execute(request, reservationId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/msg/team1/Hi/domain/home_base/presentation/controller/student/StudentHomeBaseController.java
+++ b/src/main/java/msg/team1/Hi/domain/home_base/presentation/controller/student/StudentHomeBaseController.java
@@ -2,11 +2,13 @@ package msg.team1.Hi.domain.home_base.presentation.controller.student;
 
 import lombok.RequiredArgsConstructor;
 import msg.team1.Hi.domain.home_base.presentation.dto.request.ReserveHomeBaseRequest;
+import msg.team1.Hi.domain.home_base.presentation.dto.request.UpdateReservationMemberRequest;
 import msg.team1.Hi.domain.home_base.presentation.dto.response.LookUpReservationDetailResponse;
 import msg.team1.Hi.domain.home_base.presentation.dto.response.LookUpReservationResponse;
 import msg.team1.Hi.domain.home_base.service.ReserveHomeBaseService;
 import msg.team1.Hi.domain.reservation.service.GetAllReservationService;
 import msg.team1.Hi.domain.reservation.service.GetReservationService;
+import msg.team1.Hi.domain.reservation.service.UpdateReservationMemberService;
 import msg.team1.Hi.domain.reservation.service.UpdateReservationTeamNameService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +26,7 @@ public class StudentHomeBaseController {
     private final GetAllReservationService getAllReservationService;
     private final GetReservationService getReservationService;
     private final UpdateReservationTeamNameService updateReservationTeamNameService;
+    private final UpdateReservationMemberService updateReservationMemberService;
 
     @PostMapping("/reserve")
     public ResponseEntity<Void> reserveHomeBase(@Valid @RequestBody ReserveHomeBaseRequest request) {
@@ -47,6 +50,12 @@ public class StudentHomeBaseController {
     @PatchMapping("/{reservation_id}/name")
     public ResponseEntity<Void> updateReservationTeamName(@PathVariable("reservation_id") Long reservationId, @RequestParam String teamName){
         updateReservationTeamNameService.execute(reservationId, teamName);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{reservation_id}/update-member")
+    public ResponseEntity<Void> updateReservationMembers(@PathVariable("reservation_id") Long reservationId, @RequestBody UpdateReservationMemberRequest request) {
+        updateReservationMemberService.execute(request, reservationId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/msg/team1/Hi/domain/home_base/presentation/controller/student/StudentHomeBaseController.java
+++ b/src/main/java/msg/team1/Hi/domain/home_base/presentation/controller/student/StudentHomeBaseController.java
@@ -54,7 +54,7 @@ public class StudentHomeBaseController {
     }
 
     @PatchMapping("/{reservation_id}/update-member")
-    public ResponseEntity<Void> updateReservationMembers(@PathVariable("reservation_id") Long reservationId, @RequestBody UpdateReservationMemberRequest request) {
+    public ResponseEntity<Void> updateReservationMembers(@PathVariable("reservation_id") Long reservationId, @RequestBody @Valid UpdateReservationMemberRequest request) {
         updateReservationMemberService.execute(request, reservationId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/msg/team1/Hi/domain/home_base/presentation/dto/request/ReserveHomeBaseRequest.java
+++ b/src/main/java/msg/team1/Hi/domain/home_base/presentation/dto/request/ReserveHomeBaseRequest.java
@@ -20,5 +20,5 @@ public class ReserveHomeBaseRequest {
     @NotNull
     private Integer period;
     @NotEmpty
-    private List<Integer> members;
+    private List<Long> members;
 }

--- a/src/main/java/msg/team1/Hi/domain/home_base/presentation/dto/request/UpdateReservationMemberRequest.java
+++ b/src/main/java/msg/team1/Hi/domain/home_base/presentation/dto/request/UpdateReservationMemberRequest.java
@@ -9,6 +9,6 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class UpdateReservationRequest {
+public class UpdateReservationMemberRequest {
     private List<Long> members;
 }

--- a/src/main/java/msg/team1/Hi/domain/home_base/presentation/dto/request/UpdateReservationRequest.java
+++ b/src/main/java/msg/team1/Hi/domain/home_base/presentation/dto/request/UpdateReservationRequest.java
@@ -1,0 +1,14 @@
+package msg.team1.Hi.domain.home_base.presentation.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateReservationRequest {
+    private List<Long> members;
+}

--- a/src/main/java/msg/team1/Hi/domain/member/repository/MemberRepository.java
+++ b/src/main/java/msg/team1/Hi/domain/member/repository/MemberRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Integer> {
     Optional<Member> findByEmail(String email);
     Optional<Member> findByName(String name);
-    List<Member> findByReservation(Reservation reservation);
+    List<Member> findAllByReservation(Reservation reservation);
     boolean existsByEmail(String email);
 
 }

--- a/src/main/java/msg/team1/Hi/domain/member/repository/MemberRepository.java
+++ b/src/main/java/msg/team1/Hi/domain/member/repository/MemberRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface MemberRepository extends JpaRepository<Member, Integer> {
+public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
     Optional<Member> findByName(String name);
     List<Member> findAllByReservation(Reservation reservation);

--- a/src/main/java/msg/team1/Hi/domain/reservation/service/GetReservationService.java
+++ b/src/main/java/msg/team1/Hi/domain/reservation/service/GetReservationService.java
@@ -24,7 +24,7 @@ public class GetReservationService {
     public LookUpReservationDetailResponse execute(Long reservationId) {
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new NotFoundReservationException("존재하지 않는 예약현황입니다."));
-        List<Member> reservedMembers = memberRepository.findByReservation(reservation);
+        List<Member> reservedMembers = memberRepository.findAllByReservation(reservation);
         List<MemberInfoResponse> memberInfoList = memberUtil
                 .memberListToDtoList(reservedMembers);
 

--- a/src/main/java/msg/team1/Hi/domain/reservation/service/UpdateReservationMemberService.java
+++ b/src/main/java/msg/team1/Hi/domain/reservation/service/UpdateReservationMemberService.java
@@ -25,6 +25,7 @@ public class UpdateReservationMemberService {
         List<Member> prevMembers = memberRepository.findAllByReservation(reservation);
         for (Member member : prevMembers) {
             member.updateStatus(UseStatus.AVAILABLE);
+            member.updateReservation(null);
         }
         memberRepository.saveAll(prevMembers);
     }

--- a/src/main/java/msg/team1/Hi/domain/reservation/service/UpdateReservationMemberService.java
+++ b/src/main/java/msg/team1/Hi/domain/reservation/service/UpdateReservationMemberService.java
@@ -12,6 +12,7 @@ import msg.team1.Hi.global.annotation.TransactionalService;
 import msg.team1.Hi.global.util.MemberUtil;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @TransactionalService
 @RequiredArgsConstructor
@@ -22,12 +23,9 @@ public class UpdateReservationMemberService {
     private final ReservationRepository reservationRepository;
 
     private void updatePrevMemberUseStatus(Reservation reservation) {
-        List<Member> prevMembers = memberRepository.findAllByReservation(reservation);
-        for (Member member : prevMembers) {
-            member.updateStatus(UseStatus.AVAILABLE);
-            member.updateReservation(null);
-        }
-        memberRepository.saveAll(prevMembers);
+        memberRepository.saveAll(memberRepository.findAllByReservation(reservation).stream()
+                .map(m ->{ m.updateStatus(UseStatus.AVAILABLE) , m.updateReservation(null)})
+                .collect(Collectors.toList()));
     }
 
     public void execute(UpdateReservationMemberRequest updateReservationRequest, Long reservationId) {

--- a/src/main/java/msg/team1/Hi/domain/reservation/service/UpdateReservationMemberService.java
+++ b/src/main/java/msg/team1/Hi/domain/reservation/service/UpdateReservationMemberService.java
@@ -21,7 +21,7 @@ public class UpdateReservationMemberService {
     private final MemberRepository memberRepository;
     private final ReservationRepository reservationRepository;
 
-    public void updatePrevMemberUseStatus(Reservation reservation) {
+    private void updatePrevMemberUseStatus(Reservation reservation) {
         List<Member> prevMembers = memberRepository.findAllByReservation(reservation);
         for (Member member : prevMembers) {
             member.updateStatus(UseStatus.AVAILABLE);

--- a/src/main/java/msg/team1/Hi/domain/reservation/service/UpdateReservationMemberService.java
+++ b/src/main/java/msg/team1/Hi/domain/reservation/service/UpdateReservationMemberService.java
@@ -1,7 +1,7 @@
 package msg.team1.Hi.domain.reservation.service;
 
 import lombok.RequiredArgsConstructor;
-import msg.team1.Hi.domain.home_base.presentation.dto.request.UpdateReservationRequest;
+import msg.team1.Hi.domain.home_base.presentation.dto.request.UpdateReservationMemberRequest;
 import msg.team1.Hi.domain.member.entity.Member;
 import msg.team1.Hi.domain.member.entity.enum_type.UseStatus;
 import msg.team1.Hi.domain.member.repository.MemberRepository;
@@ -29,7 +29,7 @@ public class UpdateReservationMemberService {
         memberRepository.saveAll(prevMembers);
     }
 
-    public void execute(UpdateReservationRequest updateReservationRequest, Long reservationId) {
+    public void execute(UpdateReservationMemberRequest updateReservationRequest, Long reservationId) {
 
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new NotFoundReservationException("존재하지 않는 예약현황 입니다."));

--- a/src/main/java/msg/team1/Hi/domain/reservation/service/UpdateReservationMemberService.java
+++ b/src/main/java/msg/team1/Hi/domain/reservation/service/UpdateReservationMemberService.java
@@ -1,0 +1,27 @@
+package msg.team1.Hi.domain.reservation.service;
+
+import lombok.RequiredArgsConstructor;
+import msg.team1.Hi.domain.home_base.presentation.dto.request.UpdateReservationRequest;
+import msg.team1.Hi.domain.member.repository.MemberRepository;
+import msg.team1.Hi.domain.reservation.entity.Reservation;
+import msg.team1.Hi.domain.reservation.exception.NotFoundReservationException;
+import msg.team1.Hi.domain.reservation.repository.ReservationRepository;
+import msg.team1.Hi.global.annotation.TransactionalService;
+import msg.team1.Hi.global.util.MemberUtil;
+
+@TransactionalService
+@RequiredArgsConstructor
+public class UpdateReservationMemberService {
+
+    private final MemberUtil memberUtil;
+    private final MemberRepository memberRepository;
+    private final ReservationRepository reservationRepository;
+
+    public void execute(UpdateReservationRequest updateReservationRequest, Long reservationId) {
+
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new NotFoundReservationException("존재하지 않는 예약현황 입니다."));
+
+
+    }
+}

--- a/src/main/java/msg/team1/Hi/domain/reservation/service/UpdateReservationMemberService.java
+++ b/src/main/java/msg/team1/Hi/domain/reservation/service/UpdateReservationMemberService.java
@@ -2,12 +2,16 @@ package msg.team1.Hi.domain.reservation.service;
 
 import lombok.RequiredArgsConstructor;
 import msg.team1.Hi.domain.home_base.presentation.dto.request.UpdateReservationRequest;
+import msg.team1.Hi.domain.member.entity.Member;
+import msg.team1.Hi.domain.member.entity.enum_type.UseStatus;
 import msg.team1.Hi.domain.member.repository.MemberRepository;
 import msg.team1.Hi.domain.reservation.entity.Reservation;
 import msg.team1.Hi.domain.reservation.exception.NotFoundReservationException;
 import msg.team1.Hi.domain.reservation.repository.ReservationRepository;
 import msg.team1.Hi.global.annotation.TransactionalService;
 import msg.team1.Hi.global.util.MemberUtil;
+
+import java.util.List;
 
 @TransactionalService
 @RequiredArgsConstructor
@@ -17,11 +21,25 @@ public class UpdateReservationMemberService {
     private final MemberRepository memberRepository;
     private final ReservationRepository reservationRepository;
 
+    public void updatePrevMemberUseStatus(Reservation reservation) {
+        List<Member> prevMembers = memberRepository.findAllByReservation(reservation);
+        for (Member member : prevMembers) {
+            member.updateStatus(UseStatus.AVAILABLE);
+        }
+        memberRepository.saveAll(prevMembers);
+    }
+
     public void execute(UpdateReservationRequest updateReservationRequest, Long reservationId) {
 
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new NotFoundReservationException("존재하지 않는 예약현황 입니다."));
 
+       updatePrevMemberUseStatus(reservation);
 
+        List<Member> members = memberUtil.convertMemberIdListToMemberList(updateReservationRequest.getMembers());
+        members.forEach(m -> m.updateReservation(reservation));
+        members.forEach(m -> m.updateStatus(UseStatus.INUSE));
+
+        memberRepository.saveAll(members);
     }
 }

--- a/src/main/java/msg/team1/Hi/domain/reservation/service/UpdateReservationMemberService.java
+++ b/src/main/java/msg/team1/Hi/domain/reservation/service/UpdateReservationMemberService.java
@@ -31,7 +31,7 @@ public class UpdateReservationMemberService {
 
     public void execute(UpdateReservationMemberRequest updateReservationRequest, Long reservationId) {
 
-        Reservation reservation = reservationRepository.findById(reservationId)
+        Reservation reservation = reservationRepository.findByIdAndRepresentative(reservationId, memberUtil.currentMember())
                 .orElseThrow(() -> new NotFoundReservationException("존재하지 않는 예약현황 입니다."));
 
        updatePrevMemberUseStatus(reservation);

--- a/src/main/java/msg/team1/Hi/global/util/MemberUtil.java
+++ b/src/main/java/msg/team1/Hi/global/util/MemberUtil.java
@@ -32,7 +32,7 @@ public class MemberUtil {
             throw new MisMatchPasswordException("비밀번호가 일치하지 않음");
     }
 
-    public List<Member> convertMemberIdListToMemberList(List<Integer> memberIdList){
+    public List<Member> convertMemberIdListToMemberList(List<Long> memberIdList){
         return memberIdList.stream()
                 .map(m -> memberRepository.findById(m).orElseThrow(() -> new MemberNotFoundException("존재하지 않는 멤버입니다.")))
                 .collect(Collectors.toList());


### PR DESCRIPTION
### 💡 개요
홈베이스 예약 명단 수정 api
### 📃 작업내용
홈베이스 대표자가 예약 명단을 수정할 수 있도록 서비스 작성
### 🔀 변경사항

### 🙋‍♂️ 질문사항

### ⚗️ 사용법

### 🎸 기타
예약 명단 업데이트 상태 흐름이 일단 예약명단 업데이트 전 멤버들을 avaliable로 바꾸고 예약현황을 없앤다 그리고 다시 새로 들어온 멤버와 매핑한다.